### PR TITLE
Fix typos which led to call of unknown functions

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -46,9 +46,9 @@ class ReSpeaker_4mic_hat(MycroftSkill):
 				self.handle_listener_off)
 
 		self.add_event('mycroft.skill.handler.start',
-				self.handler_listener_think)
+				self.handle_listener_think)
 		self.add_event('mycroft.skill.handler.complete',
-				self.handler_listener_off)
+				self.handle_listener_off)
 
 		self.add_event('recognizer_loop:audio_output_start',
 				self.handler_listener_speak)


### PR DESCRIPTION
This pull request fixes some typos in the handler function naming. Now the mic array's led ring lights up on hotword detection instead of blinking once and crashing then.